### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins as they are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,9 @@ requirements:
     build:
       - {{ compiler('c') }}
       - {{ compiler('cxx') }}
+      # Use pins to control cos6/cos7 match
+      - libgcc-ng  {{ libgcc }}                             # [x86_64 and c_compiler_version == "7.2.*"]
+      - libstdcxx-ng  {{ libstdcxx }}                       # [x86_64 and c_compiler_version == "7.2.*"]
       - make
       - python {{ python }}
       - pkg-config  # [unix]
@@ -30,6 +33,9 @@ requirements:
       - libvorbis {{ libvorbis }}
       - libogg {{ libogg }}
       - libopus  {{ libopus }}
+      # Use pins to control cos6/cos7 match
+      - libgcc-ng  {{ libgcc }}                             # [x86_64 and c_compiler_version == "7.2.*"]
+      - libstdcxx-ng  {{ libstdcxx }}                       # [x86_64 and c_compiler_version == "7.2.*"]
     run:
       - libflac
       - libvorbis                      # versioning handled by run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 1
+    number: 2
     string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
     run_exports:
         # https://abi-laboratory.pro/?view=timeline&l=libsndfile
@@ -22,9 +22,6 @@ requirements:
     build:
       - {{ compiler('c') }}
       - {{ compiler('cxx') }}
-      # Use pins to control cos6/cos7 match
-      - libgcc-ng  {{ libgcc }}
-      - libstdcxx-ng  {{ libstdcxx }}
       - make
       - python {{ python }}
       - pkg-config  # [unix]
@@ -33,9 +30,6 @@ requirements:
       - libvorbis {{ libvorbis }}
       - libogg {{ libogg }}
       - libopus  {{ libopus }}
-      # Use pins to control cos6/cos7 match
-      - libgcc-ng  {{ libgcc }}
-      - libstdcxx-ng  {{ libstdcxx }}
     run:
       - libflac
       - libvorbis                      # versioning handled by run_exports


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
